### PR TITLE
Added functionality to fetch current semester's courses

### DIFF
--- a/states/render-messages.js
+++ b/states/render-messages.js
@@ -25,32 +25,30 @@ export const renderCourses = (courses) => {
   const toPercent = (total, went) => ((went * 100) / total).toFixed(2);
   for (let i = 0; i < courses.courses.length; i += 1) {
     const course = courses.courses[i];
-    const code = course.ref.code;
-    const name = course.ref.name;
-    const type = course.type;
-    const attendance = `${course.attendance.attended}/${course.attendance.held} (${toPercent(
-      course.attendance.held,
-      course.attendance.attended
-    )}%)`;
+    const { type } = course;
+    const { code, name } = course.ref;
+    const attendance = `${course.attendance.attended}/${
+      course.attendance.held
+    } (${toPercent(course.attendance.held, course.attendance.attended)}%)`;
     const internalMarks = `${course.internalMarks.have}/${course.internalMarks.max}`;
-    text += `*Course*: ${name} *| Code*: ${code}
-        *Type*: ${type}
-        *Attendance*: ${attendance}
-        *Internal Marks*: ${internalMarks}
-        
+    text += `
+*Course*: ${name} *| Code*: ${code}
+*Type*: ${type}
+*Attendance*: ${attendance}
+*Internal Marks*: ${internalMarks}
 `;
   }
   return text;
-}
+};
 
 export const renderSchedule = (schedule) => {
   let text = "";
   text = `*------ Date: ${schedule.classes[0].startTime.substr(0, 10)} ------*
-  
+
 `;
   for (let i = 0; i < schedule.classes.length; i += 1) {
     const record = schedule.classes[i];
-    text += `*Course* :${record.course.name} 
+    text += `*Course* :${record.course.name}
 *Faculty Name* :${record.faculty}
 *Room* :${record.room}
 *Time* :${record.startTime.substr(11, 5)} - ${record.endTime.substr(11, 5)}
@@ -67,7 +65,7 @@ export const renderSemester = (semesters) => {
 `;
   for (let i = 1; i < semesters.semesters.length; i += 1) {
     const record = semesters.semesters[i];
-    text += `*Semester* :${record.name} 
+    text += `*Semester* :${record.name}
 
 `;
   }

--- a/states/render-messages.js
+++ b/states/render-messages.js
@@ -20,6 +20,29 @@ export const renderAttendance = (attendance) => {
   return text;
 };
 
+export const renderCourses = (courses) => {
+  let text = "";
+  const toPercent = (total, went) => ((went * 100) / total).toFixed(2);
+  for (let i = 0; i < courses.courses.length; i += 1) {
+    const course = courses.courses[i];
+    const code = course.ref.code;
+    const name = course.ref.name;
+    const type = course.type;
+    const attendance = `${course.attendance.attended}/${course.attendance.held} (${toPercent(
+      course.attendance.held,
+      course.attendance.attended
+    )}%)`;
+    const internalMarks = `${course.internalMarks.have}/${course.internalMarks.max}`;
+    text += `*Course*: ${name} *| Code*: ${code}
+        *Type*: ${type}
+        *Attendance*: ${attendance}
+        *Internal Marks*: ${internalMarks}
+        
+`;
+  }
+  return text;
+}
+
 export const renderSchedule = (schedule) => {
   let text = "";
   text = `*------ Date: ${schedule.classes[0].startTime.substr(0, 10)} ------*

--- a/states/state_handlers.js
+++ b/states/state_handlers.js
@@ -155,14 +155,16 @@ const optionsMap = new Map([
       try {
         const amizoneClient = newAmizoneClient(ctx);
         const semesters = await amizoneClient.amizoneServiceGetSemesters();
-        const currentSemester = parseInt(semesters.data.semesters[0].name);
+        const currentSemester = parseInt(semesters.data.semesters[0].name, 10);
         // @todo Send a response to ask the user about which semester's courses he/she wants
-        const courses = await amizoneClient.amizoneServiceGetCourses(currentSemester);
+        const courses = await amizoneClient.amizoneServiceGetCourses(
+          currentSemester
+        );
         return [true, renderCourses(courses.data)];
       } catch (err) {
-        return [false, ""]
+        return [false, ""];
       }
-    }
+    },
   ],
   [
     loggedInOptions.GET_SEMESTERS,
@@ -179,7 +181,7 @@ const optionsMap = new Map([
       }
     },
   ],
-  [loggedInOptions.GET_MENU, async (ctx) => [true, ""]],
+  [loggedInOptions.GET_MENU, async (_ctx) => [true, ""]],
 ]);
 
 /**

--- a/states/state_handlers.js
+++ b/states/state_handlers.js
@@ -3,6 +3,7 @@ import { states } from "./states.js";
 import {
   renderAmizoneMenu,
   renderAttendance,
+  renderCourses,
   renderSemester,
   renderSchedule,
   renderWelcomeMessage,
@@ -149,6 +150,21 @@ const optionsMap = new Map([
       [true, "list"],
   ],
   [
+    loggedInOptions.GET_COURSES,
+    async (ctx) => {
+      try {
+        const amizoneClient = newAmizoneClient(ctx);
+        const semesters = await amizoneClient.amizoneServiceGetSemesters();
+        const currentSemester = parseInt(semesters.data.semesters[0].name);
+        // @todo Send a response to ask the user about which semester's courses he/she wants
+        const courses = await amizoneClient.amizoneServiceGetCourses(currentSemester);
+        return [true, renderCourses(courses.data)];
+      } catch (err) {
+        return [false, ""]
+      }
+    }
+  ],
+  [
     loggedInOptions.GET_SEMESTERS,
     async (ctx) => {
       try {
@@ -254,6 +270,6 @@ export const handleUseDate = async (ctx) => {
   await ctx.bot
     .sendMessage(ctx.payload.sender, "invalid date!")
     .catch((err) => console.error("failed to send message to WA: ", err));
-    await ctx.bot.sendDateList(payload.sender);
+  await ctx.bot.sendDateList(payload.sender);
   return updatedUser;
 };


### PR DESCRIPTION
The courses option on the menu should now return the details of the current semester's courses (if nothing goes wrong).
This also solves issue #19 
I have checked the response on terminal and it works as expected, but since I don't have any valid WHATSAPP_TOKEN, I can't check its response on whatsapp.