### PR TITLE
ci: auto deploy on pushes to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,15 @@
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## What

Adds a GitHub Actions-powered workflow that deploys Amibot to fly.io every time there's a push to `main`

## Why?

I expect Amibot to evolve. Manual intervention to keep the deployment updated can become impractical.

